### PR TITLE
Don't prohibit complex modifiers (e.g. public final)

### DIFF
--- a/spanner-library/src/main/java/dk/ilios/spanner/benchmark/BenchmarkClass.java
+++ b/spanner-library/src/main/java/dk/ilios/spanner/benchmark/BenchmarkClass.java
@@ -136,7 +136,7 @@ public final class BenchmarkClass {
 
     private void verifyBenchmarkMethod(Method method) throws InvalidBenchmarkException {
         int modifiers = method.getModifiers();
-        if (modifiers != Modifier.PUBLIC) {
+        if ((modifiers & Modifier.PUBLIC) != Modifier.PUBLIC) {
             throw new InvalidBenchmarkException("Benchmark methods must only be public: " + method.getName());
         }
 
@@ -155,7 +155,7 @@ public final class BenchmarkClass {
 
     private void verifyCustomMeasurementMethod(Method method) throws InvalidBenchmarkException {
         int modifiers = method.getModifiers();
-        if (modifiers != Modifier.PUBLIC) {
+        if ((modifiers & Modifier.PUBLIC) != Modifier.PUBLIC) {
             throw new InvalidBenchmarkException("Benchmark methods must only be public: " + method.getName());
         }
 


### PR DESCRIPTION
By default Kotlin makes every class and method `final` so it cannot be used without an explicit `open` modifier as the resulting `public final` modifier wouldn't be accepted as a valid benchmark.